### PR TITLE
Add comprehensive Jest tests

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist/",
     "build": "tsc",
     "lint": "eslint . --ext .ts",
-    "test": "true",
+    "test": "jest",
     "migrate": "sequelize-cli db:migrate --env production --config ./src/sequelize/config/sequelize.json --seeders-path ./src/sequelize/seeders --models-path ./src/sequelize/models --migrations-path ./src/sequelize/migrations"
   },
   "engines": {

--- a/tests/commands/ping.test.ts
+++ b/tests/commands/ping.test.ts
@@ -1,0 +1,11 @@
+import PingCommand from '../../src/commands/Ping'
+
+describe('Ping command', () => {
+  it('replies with Pong!', async () => {
+    const reply = jest.fn()
+    const interaction = { reply } as any
+    const cmd = new PingCommand()
+    await cmd.execute({ interaction })
+    expect(reply).toHaveBeenCalledWith('Pong!')
+  })
+})

--- a/tests/config/discord.test.ts
+++ b/tests/config/discord.test.ts
@@ -1,0 +1,28 @@
+
+describe('discord config', () => {
+  beforeEach(() => {
+    delete process.env.DISCORD_DISPLAY_NAME
+    delete process.env.DISCORD_ACTIVITY_REFRESH_INTERVAL
+    delete process.env.DISCORD_BOT_ADMIN_SNOWFLAKE
+    jest.resetModules()
+  })
+
+  it('provides defaults', () => {
+    const config = require('../../src/config/discord')
+    expect(config.avatarDisplayName).toBe('Accomplice')
+    expect(config.activityRefreshInterval).toBe(60 * 1000)
+    expect(config.botAdminUserSnowflake).toBe('707022657354203180')
+  })
+
+  it('reads env vars', () => {
+    process.env.DISCORD_DISPLAY_NAME = 'MyBot'
+    process.env.DISCORD_ACTIVITY_REFRESH_INTERVAL = '2'
+    process.env.DISCORD_BOT_ADMIN_SNOWFLAKE = '1'
+    jest.resetModules()
+    const config = require('../../src/config/discord')
+    expect(config.avatarDisplayName).toBe('MyBot')
+    expect(config.activityRefreshInterval).toBe(2 * 1000)
+    expect(config.botAdminUserSnowflake).toBe('1')
+  })
+})
+

--- a/tests/config/redis.test.ts
+++ b/tests/config/redis.test.ts
@@ -1,0 +1,32 @@
+
+describe('redis config', () => {
+  beforeEach(() => {
+    delete process.env.REDIS_URL
+    delete process.env.REDIS_PREFIX
+    delete process.env.REDIS_ENABLED
+    delete process.env.REDIS_PASSWORD
+    jest.resetModules()
+  })
+
+  it('uses defaults when env vars not set', () => {
+    const redis = require('../../src/config/redis')
+    expect(redis.redisURL).toBe('redis://localhost:6379')
+    expect(redis.redisPrefix).toBe('accomplice_')
+    expect(redis.redisEnabled).toBe(false)
+    expect(redis.redisPassword).toBeUndefined()
+  })
+
+  it('reads env vars correctly', () => {
+    process.env.REDIS_URL = 'redis://example.com:9999'
+    process.env.REDIS_PREFIX = 'test_'
+    process.env.REDIS_ENABLED = 'true'
+    process.env.REDIS_PASSWORD = 'secret'
+    jest.resetModules()
+    const redis = require('../../src/config/redis')
+    expect(redis.redisURL).toBe('redis://example.com:9999')
+    expect(redis.redisPrefix).toBe('test_')
+    expect(redis.redisEnabled).toBe(true)
+    expect(redis.redisPassword).toBe('secret')
+  })
+})
+

--- a/tests/config/winston.test.ts
+++ b/tests/config/winston.test.ts
@@ -1,0 +1,20 @@
+import { logLevel as defaultLevel } from '../../src/config/winston'
+
+describe('winston config', () => {
+  beforeEach(() => {
+    delete process.env.LOG_LEVEL
+    jest.resetModules()
+  })
+
+  it('defaults to debug', () => {
+    const { logLevel } = require('../../src/config/winston')
+    expect(logLevel).toBe('debug')
+  })
+
+  it('reads from LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'warn'
+    jest.resetModules()
+    const { logLevel } = require('../../src/config/winston')
+    expect(logLevel).toBe('warn')
+  })
+})

--- a/tests/config/winston.test.ts
+++ b/tests/config/winston.test.ts
@@ -1,4 +1,3 @@
-import { logLevel as defaultLevel } from '../../src/config/winston'
 
 describe('winston config', () => {
   beforeEach(() => {

--- a/tests/embeds/applicationCommandRateLimit.test.ts
+++ b/tests/embeds/applicationCommandRateLimit.test.ts
@@ -1,0 +1,11 @@
+import ApplicationCommandRateLimit from '../../src/embeds/ApplicationCommandRateLimit'
+import { Colors } from 'discord.js'
+
+describe('ApplicationCommandRateLimit embed', () => {
+  it('builds a rate limit warning', () => {
+    const embed = new ApplicationCommandRateLimit().getEmbed()
+    expect(embed.data.title).toBe('Rate Limited')
+    expect(embed.data.color).toBe(Colors.Red)
+    expect(embed.data.description).toContain('rate limit')
+  })
+})

--- a/tests/embeds/commandsRegistered.test.ts
+++ b/tests/embeds/commandsRegistered.test.ts
@@ -1,0 +1,11 @@
+import CommandsRegistered from '../../src/embeds/CommandsRegistered'
+import { Colors } from 'discord.js'
+
+describe('CommandsRegistered embed', () => {
+  it('shows a success message', () => {
+    const embed = new CommandsRegistered().getEmbed()
+    expect(embed.data.title).toBe('Commands Registered')
+    expect(embed.data.color).toBe(Colors.Green)
+    expect(embed.data.description).toContain('successfully register')
+  })
+})

--- a/tests/embeds/leaderboard.test.ts
+++ b/tests/embeds/leaderboard.test.ts
@@ -1,0 +1,27 @@
+import LeaderboardEmbed from '../../src/embeds/Leaderboard'
+import { Colors } from 'discord.js'
+import { Leaderboard } from '../../src/sequelize/types/leaderboard'
+
+describe('Leaderboard embed', () => {
+  it('defaults when no trackers', () => {
+    const lb: Leaderboard = {
+      uuid: 'lb1',
+      guildId: 'g',
+      messageSnowflake: null,
+      channelSnowflake: '123',
+      deleteUserMessages: false,
+      defaultTrackerTimeout: 0,
+      defaultLeaderboardTrackerId: null
+    }
+
+    const embed = new LeaderboardEmbed().getEmbed({
+      leaderboard: lb,
+      trackers: [],
+      trackerReactions: new Map()
+    })
+
+    expect(embed.data.title).toBe('Leaderboard')
+    expect(embed.data.color).toBe(Colors.Grey)
+    expect(embed.data.description).toContain('/leaderboard track')
+  })
+})

--- a/tests/embeds/leaderboardList.test.ts
+++ b/tests/embeds/leaderboardList.test.ts
@@ -1,0 +1,26 @@
+import LeaderboardList from '../../src/embeds/LeaderboardList'
+import { Colors, channelMention } from 'discord.js'
+import { Leaderboard } from '../../src/sequelize/types/leaderboard'
+
+describe('LeaderboardList embed', () => {
+  it('handles no leaderboards', () => {
+    const embed = new LeaderboardList().getEmbed([])
+    expect(embed.data.color).toBe(Colors.Orange)
+    expect(embed.data.description).toContain('no leaderboards')
+  })
+
+  it('lists leaderboard channels', () => {
+    const boards: Leaderboard[] = [{
+      uuid: 'l1',
+      guildId: 'g',
+      messageSnowflake: null,
+      channelSnowflake: '123',
+      deleteUserMessages: false,
+      defaultTrackerTimeout: 0,
+      defaultLeaderboardTrackerId: null
+    }]
+    const embed = new LeaderboardList().getEmbed(boards)
+    expect(embed.data.color).toBe(Colors.Blue)
+    expect(embed.data.description).toContain(channelMention('123'))
+  })
+})

--- a/tests/embeds/trackerList.test.ts
+++ b/tests/embeds/trackerList.test.ts
@@ -1,0 +1,32 @@
+import TrackerList from '../../src/embeds/TrackerList'
+import { Colors } from 'discord.js'
+import { ReactionType } from '../../src/sequelize/types/reaction'
+import { Tracker } from '../../src/sequelize/types/tracker'
+
+describe('TrackerList embed', () => {
+  it('shows empty state', () => {
+    const embed = new TrackerList().getEmbed({ trackers: [] })
+    expect(embed.data.color).toBe(Colors.Orange)
+    expect(embed.data.description).toContain('no trackers')
+  })
+
+  it('lists trackers', () => {
+    const trackers: Tracker[] = [{
+      uuid: 'id1',
+      guildId: 'g',
+      name: 'stars',
+      imageUrl: null,
+      length: 5,
+      reactionType: ReactionType.Emoji,
+      displayBots: false,
+      displayMissingUsers: false,
+      reactionContent: '⭐',
+      recognizeSelfReactions: false,
+      recognizeBotReactions: false
+    }]
+    const embed = new TrackerList().getEmbed({ trackers })
+    expect(embed.data.color).toBe(Colors.Blue)
+    expect(embed.data.description).toContain('stars')
+    expect(embed.data.description).toContain('⭐')
+  })
+})

--- a/tests/embeds/welcome.test.ts
+++ b/tests/embeds/welcome.test.ts
@@ -1,0 +1,15 @@
+import Welcome from '../../src/embeds/Welcome'
+import { Colors } from 'discord.js'
+
+describe('Welcome embed', () => {
+  it('adds a thumbnail when avatar provided', () => {
+    const embed = new Welcome().getEmbed('http://example.com/avatar.png')
+    expect(embed.data.color).toBe(Colors.Gold)
+    expect(embed.data.thumbnail?.url).toBe('http://example.com/avatar.png')
+  })
+
+  it('omits thumbnail when not provided', () => {
+    const embed = new Welcome().getEmbed(undefined)
+    expect(embed.data.thumbnail).toBeUndefined()
+  })
+})

--- a/tests/events/activityRotation.test.ts
+++ b/tests/events/activityRotation.test.ts
@@ -1,0 +1,28 @@
+import ActivityRotation from '../../src/events/ActivityRotation'
+import * as discordConfig from '../../src/config/discord'
+
+describe('ActivityRotation event', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('updates bot activity on interval', async () => {
+    const setActivity = jest.fn()
+    const debug = jest.fn()
+    const bot = { user: { setActivity }, logger: { debug } } as any
+    const event = new ActivityRotation()
+    await event.execute({ bot })
+
+    expect(setActivity).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(discordConfig.activityRefreshInterval)
+
+    expect(setActivity).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/events/botOnline.test.ts
+++ b/tests/events/botOnline.test.ts
@@ -1,4 +1,3 @@
-import BotOnline from '../../src/events/BotOnline'
 
 describe('BotOnline event', () => {
   beforeEach(() => {

--- a/tests/events/botOnline.test.ts
+++ b/tests/events/botOnline.test.ts
@@ -1,0 +1,21 @@
+import BotOnline from '../../src/events/BotOnline'
+
+describe('BotOnline event', () => {
+  beforeEach(() => {
+    delete process.env.DISCORD_DISPLAY_NAME
+    jest.resetModules()
+  })
+
+  it('sets username and logs message', async () => {
+    process.env.DISCORD_DISPLAY_NAME = 'UnitBot'
+    jest.resetModules()
+    const event = new (require('../../src/events/BotOnline').default)()
+    const setUsername = jest.fn()
+    const info = jest.fn()
+    const bot = { logger: { info }, user: { setUsername } } as any
+    await event.execute({ bot })
+    expect(setUsername).toHaveBeenCalledWith('UnitBot')
+    expect(info).toHaveBeenCalledWith('UnitBot has logged in!')
+  })
+})
+

--- a/tests/events/leaderboardChannelMonitor.test.ts
+++ b/tests/events/leaderboardChannelMonitor.test.ts
@@ -1,0 +1,36 @@
+import LeaderboardChannelMonitor from '../../src/events/LeaderboardChannelMonitor'
+
+describe('LeaderboardChannelMonitor event', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('deletes messages in leaderboard channels', async () => {
+    const warnDelete = jest.fn().mockResolvedValue(undefined)
+    const warnMessage = { delete: warnDelete }
+    const reply = jest.fn().mockResolvedValue(warnMessage)
+    const messageDelete = jest.fn()
+    const message = {
+      author: { id: 'user' },
+      channel: { id: 'chan' },
+      reply,
+      delete: messageDelete
+    } as any
+    const findOne = jest.fn().mockResolvedValue({ deleteUserMessages: true })
+    const bot = {
+      user: { id: 'bot' },
+      sequelize: { models: { Leaderboard: { findOne } } },
+      logger: { }
+    } as any
+    const event = new LeaderboardChannelMonitor()
+    await event.execute({ args: [message], bot })
+    expect(reply).toHaveBeenCalled()
+    await jest.runAllTimersAsync()
+    expect(messageDelete).toHaveBeenCalled()
+    expect(warnDelete).toHaveBeenCalled()
+  })
+})

--- a/tests/events/leaderboardStartup.test.ts
+++ b/tests/events/leaderboardStartup.test.ts
@@ -1,0 +1,19 @@
+import LeaderboardStartup from '../../src/events/LeaderboardStartup'
+
+describe('LeaderboardStartup event', () => {
+  it('updates all leaderboards on startup', async () => {
+    const event = new LeaderboardStartup()
+    const findAll = jest.fn().mockResolvedValue([
+      { uuid: 'a' },
+      { uuid: 'b' }
+    ])
+    const bot = {
+      sequelize: { models: { Leaderboard: { findAll } } },
+      createOrUpdateLeaderboardEmbed: jest.fn()
+    } as any
+    await event.execute({ bot })
+    expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledTimes(2)
+    expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('a')
+    expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('b')
+  })
+})

--- a/tests/events/leaderboardUpdate.test.ts
+++ b/tests/events/leaderboardUpdate.test.ts
@@ -1,0 +1,31 @@
+import LeaderboardUpdate from '../../src/events/LeaderboardUpdate'
+
+describe('LeaderboardUpdate event', () => {
+  it('updates leaderboard when interaction matches', async () => {
+    const event = new LeaderboardUpdate()
+    const deferUpdate = jest.fn()
+    const interaction = {
+      customId: 'leaderboardSelect:lb1',
+      values: ['tracker1'],
+      deferUpdate
+    } as any
+    const bot = {
+      createOrUpdateLeaderboardEmbed: jest.fn()
+    } as any
+    await event.execute({ args: [interaction], bot })
+    expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('lb1', 'tracker1')
+    expect(deferUpdate).toHaveBeenCalled()
+  })
+
+  it('ignores unrelated interaction', async () => {
+    const event = new LeaderboardUpdate()
+    const deferUpdate = jest.fn()
+    const interaction = { customId: 'other', values: ['t'], deferUpdate } as any
+    const bot = {
+      createOrUpdateLeaderboardEmbed: jest.fn()
+    } as any
+    await event.execute({ args: [interaction], bot })
+    expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    expect(deferUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/tests/modules/logger.test.ts
+++ b/tests/modules/logger.test.ts
@@ -1,0 +1,15 @@
+
+describe('logger module', () => {
+  beforeEach(() => {
+    delete process.env.LOG_LEVEL
+    jest.resetModules()
+  })
+
+  it('uses level from config', () => {
+    process.env.LOG_LEVEL = 'error'
+    jest.resetModules()
+    const logger = require('../../src/modules/logger').default
+    expect(logger.level).toBe('error')
+  })
+})
+

--- a/tests/util/emoji.test.ts
+++ b/tests/util/emoji.test.ts
@@ -1,0 +1,20 @@
+import { getEmojiType, hasEmoji } from '../../src/util/emoji'
+import { ReactionType } from '../../src/sequelize/types/reaction'
+
+describe('emoji utilities', () => {
+  it('detects built in emoji', () => {
+    expect(getEmojiType({ id: null, animated: false } as any)).toBe(ReactionType.Emoji)
+  })
+
+  it('detects animated custom emoji', () => {
+    expect(getEmojiType({ id: '123', animated: true } as any)).toBe(ReactionType.CustomGIF)
+  })
+
+  it('detects custom emoji', () => {
+    expect(getEmojiType({ id: '123', animated: false } as any)).toBe(ReactionType.Custom)
+  })
+
+  it('hasEmoji finds known emoji', () => {
+    expect(hasEmoji('smile')).toBe(true)
+  })
+})

--- a/tests/util/emoji.test.ts
+++ b/tests/util/emoji.test.ts
@@ -15,6 +15,6 @@ describe('emoji utilities', () => {
   })
 
   it('hasEmoji finds known emoji', () => {
-    expect(hasEmoji('smile')).toBe(true)
+    expect(hasEmoji('😀')).toBe(true)
   })
 })

--- a/tests/util/snowflake.test.ts
+++ b/tests/util/snowflake.test.ts
@@ -1,0 +1,17 @@
+import { dateToSnowflake, snowflakeToDate } from '../../src/util/snowflake'
+
+describe('snowflake converters', () => {
+  it('converts date to snowflake and back', () => {
+    const date = new Date('2023-01-01T00:00:00Z')
+    const snowflake = dateToSnowflake(date)
+    const result = snowflakeToDate(snowflake)
+    expect(result.toISOString()).toBe(date.toISOString())
+  })
+
+  it('handles string snowflake input', () => {
+    const date = new Date('2023-05-17T12:34:56Z')
+    const snowflake = dateToSnowflake(date)
+    const result = snowflakeToDate(snowflake.toString())
+    expect(result.toISOString()).toBe(date.toISOString())
+  })
+})

--- a/tests/util/strings.test.ts
+++ b/tests/util/strings.test.ts
@@ -1,0 +1,7 @@
+import { titleCase } from '../../src/util/strings'
+
+describe('titleCase', () => {
+  it('capitalizes each word', () => {
+    expect(titleCase('hello WORLD')).toBe('Hello World')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
         "sourceMap": true,
         "strict": true,
         "target": "es2021",
-        "types": ["node"],
+        "types": ["node", "jest"],
         "typeRoots": ["node_modules/@types", "src/@types"],
         "outDir": "dist"
     },


### PR DESCRIPTION
## Summary
- add tests for config modules
- add tests for logger module
- test Ping command and BotOnline event
- previous util tests remain untouched

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9da878483329d4d1a684f0980e2