### PR TITLE
Fix unicode emoji counting

### DIFF
--- a/src/commands/Tracker.ts
+++ b/src/commands/Tracker.ts
@@ -5,7 +5,7 @@ import { LeaderboardTrackers } from '../sequelize/types/leaderboard_trackers'
 import { ReactionType } from '../sequelize/types/reaction'
 import { Tracker } from '../sequelize/types/tracker'
 import TrackerList from '../embeds/TrackerList'
-import { hasEmoji } from '../util/emoji'
+import { hasEmoji, normalizeEmoji } from '../util/emoji'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
@@ -181,7 +181,7 @@ export default class LeaderboardCommand implements Command {
 
         if (isRegularEmoji) {
             reactionType = ReactionType.Emoji
-            reactionContent = reaction
+            reactionContent = normalizeEmoji(reaction)
         } else if (guildEmojiNumbers) {
             const guildEmoji = bot.emojis.cache.get(guildEmojiNumbers)
             if (guildEmoji) {

--- a/src/embeds/Leaderboard.ts
+++ b/src/embeds/Leaderboard.ts
@@ -16,6 +16,7 @@ import {
     userMention
 } from 'discord.js'
 import { ReactionCount, ReactionType } from '../sequelize/types/reaction'
+import { denormalizeEmoji } from '../util/emoji'
 
 export default class LeaderboardEmbed implements Embed {
     public getEmbed({
@@ -53,7 +54,7 @@ export default class LeaderboardEmbed implements Embed {
                 tracker.reactionContent &&
                 tracker.reactionType === ReactionType.Emoji
             ) {
-                trackerEmoji = tracker.reactionContent
+                trackerEmoji = denormalizeEmoji(tracker.reactionContent)
             }
 
             return new StringSelectMenuOptionBuilder()
@@ -126,7 +127,7 @@ export default class LeaderboardEmbed implements Embed {
         if (tracker.reactionContent) {
             switch (tracker.reactionType) {
                 case ReactionType.Emoji:
-                    displayEmoji = tracker.reactionContent
+                    displayEmoji = denormalizeEmoji(tracker.reactionContent)
                     break
                 case ReactionType.Custom:
                     displayEmoji = formatEmoji(tracker.reactionContent)

--- a/src/embeds/TrackerList.ts
+++ b/src/embeds/TrackerList.ts
@@ -5,6 +5,7 @@ import { avatarDisplayName } from '../config/discord'
 import { isEmpty } from 'ramda'
 
 import { EmbedBuilder, bold, formatEmoji, inlineCode } from 'discord.js'
+import { denormalizeEmoji } from '../util/emoji'
 
 export default class TrackerList implements Embed {
     public getEmbed({ trackers }: { trackers: Tracker[] }): EmbedBuilder {
@@ -47,7 +48,7 @@ export default class TrackerList implements Embed {
         switch (tracker.reactionType) {
             case ReactionType.Emoji: {
                 if (tracker.reactionContent) {
-                    reaction = tracker.reactionContent
+                    reaction = denormalizeEmoji(tracker.reactionContent)
                 }
                 break
             }

--- a/src/events/ReactionAdded.ts
+++ b/src/events/ReactionAdded.ts
@@ -3,7 +3,7 @@ import EventHandle from '../types/EventHandle'
 import { Guild } from '../sequelize/types/guild'
 import { Reaction } from '../sequelize/types/reaction'
 import { User } from '../sequelize/types/user'
-import { getEmojiType } from '../util/emoji'
+import { getEmojiType, normalizeEmoji } from '../util/emoji'
 import { isEmpty } from 'ramda'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -143,7 +143,10 @@ export default class ReactionAdded implements EventHandle {
                 uuid: uuidv4(),
                 guildId: guildRow.uuid,
                 type: emojiType,
-                content: emoji.name,
+                content:
+                    emojiType === ReactionType.Emoji && emoji.name
+                        ? normalizeEmoji(emoji.name)
+                        : emoji.name,
                 emojiId: emoji.id || null,
                 messageSnowflake: messageReaction.message.id,
                 reacteeUserId: reactee.uuid,

--- a/src/events/ReactionRemoved.ts
+++ b/src/events/ReactionRemoved.ts
@@ -3,7 +3,7 @@ import EventHandle from '../types/EventHandle'
 import { Guild } from '../sequelize/types/guild'
 import { Reaction } from '../sequelize/types/reaction'
 import { User } from '../sequelize/types/user'
-import { getEmojiType } from '../util/emoji'
+import { getEmojiType, normalizeEmoji } from '../util/emoji'
 import { isEmpty } from 'ramda'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -140,7 +140,10 @@ export default class ReactionRemoved implements EventHandle {
                 where: {
                     guildId: guildRow.uuid,
                     type: emojiType,
-                    content: emoji.name,
+                    content:
+                        emojiType === ReactionType.Emoji && emoji.name
+                            ? normalizeEmoji(emoji.name)
+                            : emoji.name,
                     emojiId: emoji.id || null,
                     reacteeUserId: reactee.uuid,
                     reactorUserId: reactor.uuid

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -13,3 +13,16 @@ export function getEmojiType(
 
 export const hasEmoji = (emoji: string): boolean =>
     Object.keys(emojilib).find(key => key === emoji) !== undefined
+
+export const normalizeEmoji = (emoji: string): string =>
+    Array.from(emoji)
+        .map(cp => cp.codePointAt(0)?.toString(16))
+        .filter(Boolean)
+        .join('-')
+
+export const denormalizeEmoji = (normalized: string): string =>
+    String.fromCodePoint(
+        ...normalized
+            .split('-')
+            .map(p => parseInt(p, 16))
+    )

--- a/tests/embeds/trackerList.test.ts
+++ b/tests/embeds/trackerList.test.ts
@@ -2,6 +2,7 @@ import TrackerList from '../../src/embeds/TrackerList'
 import { Colors } from 'discord.js'
 import { ReactionType } from '../../src/sequelize/types/reaction'
 import { Tracker } from '../../src/sequelize/types/tracker'
+import { normalizeEmoji } from '../../src/util/emoji'
 
 describe('TrackerList embed', () => {
     it('shows empty state', () => {
@@ -21,7 +22,7 @@ describe('TrackerList embed', () => {
                 reactionType: ReactionType.Emoji,
                 displayBots: false,
                 displayMissingUsers: false,
-                reactionContent: '⭐',
+                reactionContent: normalizeEmoji('⭐'),
                 recognizeSelfReactions: false,
                 recognizeBotReactions: false
             }

--- a/tests/util/emoji.test.ts
+++ b/tests/util/emoji.test.ts
@@ -1,4 +1,9 @@
-import { getEmojiType, hasEmoji } from '../../src/util/emoji'
+import {
+    getEmojiType,
+    hasEmoji,
+    normalizeEmoji,
+    denormalizeEmoji
+} from '../../src/util/emoji'
 import { ReactionType } from '../../src/sequelize/types/reaction'
 
 describe('emoji utilities', () => {
@@ -22,5 +27,11 @@ describe('emoji utilities', () => {
 
     it('hasEmoji finds known emoji', () => {
         expect(hasEmoji('😀')).toBe(true)
+    })
+
+    it('normalizes and denormalizes emoji', () => {
+        const e = '😀'
+        const normalized = normalizeEmoji(e)
+        expect(denormalizeEmoji(normalized)).toBe(e)
     })
 })


### PR DESCRIPTION
## Summary
- normalize unicode emoji before storing in the DB
- denormalize emoji when displaying tracker or leaderboard embeds
- add tests for emoji normalization

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841fabf37408332bd389a7249e0c997