### PR TITLE
Add core bot tests

### DIFF
--- a/tests/accomplice/createOrUpdateLeaderboardEmbed.test.ts
+++ b/tests/accomplice/createOrUpdateLeaderboardEmbed.test.ts
@@ -1,0 +1,108 @@
+import Accomplice from '../../src/accomplice'
+
+jest.mock('../../src/embeds/Leaderboard', () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+        getEmbed: jest.fn().mockReturnValue({}),
+        getComponents: jest.fn().mockReturnValue([])
+    }))
+}))
+
+describe('createOrUpdateLeaderboardEmbed', () => {
+    it('edits existing message when found', async () => {
+        const edit = jest.fn()
+        const leaderboard = {
+            uuid: 'lb1',
+            channelSnowflake: 'chan',
+            messageSnowflake: 'msg1',
+            defaultLeaderboardTrackerId: null
+        }
+        const Leaderboard = {
+            findOne: jest.fn().mockResolvedValue(leaderboard),
+            update: jest.fn()
+        }
+        const LeaderboardTrackers = {
+            findAll: jest.fn().mockResolvedValue([])
+        }
+        const Tracker = { findAll: jest.fn().mockResolvedValue([]) }
+        const bot = {
+            sequelize: {
+                models: { Leaderboard, LeaderboardTrackers, Tracker },
+                query: jest.fn().mockResolvedValue([])
+            },
+            channels: {
+                resolve: jest.fn().mockReturnValue({
+                    isTextBased: () => true,
+                    fetch: jest.fn(),
+                    messages: {
+                        fetch: jest.fn().mockResolvedValue(
+                            new Map([['msg1', { edit, delete: jest.fn() }]])
+                        )
+                    }
+                })
+            },
+            logger: { debug: jest.fn(), error: jest.fn() }
+        } as any
+        await Accomplice.prototype.createOrUpdateLeaderboardEmbed.call(bot, 'lb1')
+        expect(edit).toHaveBeenCalled()
+        expect(Leaderboard.update).not.toHaveBeenCalled()
+    })
+
+    it('creates message when none found', async () => {
+        const send = jest.fn().mockResolvedValue({ id: 'new' })
+        const leaderboard = {
+            uuid: 'lb1',
+            channelSnowflake: 'chan',
+            messageSnowflake: 'msg1',
+            defaultLeaderboardTrackerId: null
+        }
+        const Leaderboard = {
+            findOne: jest.fn().mockResolvedValue(leaderboard),
+            update: jest.fn()
+        }
+        const LeaderboardTrackers = {
+            findAll: jest.fn().mockResolvedValue([])
+        }
+        const Tracker = { findAll: jest.fn().mockResolvedValue([]) }
+        const bot = {
+            sequelize: {
+                models: { Leaderboard, LeaderboardTrackers, Tracker },
+                query: jest.fn().mockResolvedValue([])
+            },
+            channels: {
+                resolve: jest.fn().mockReturnValue({
+                    isTextBased: () => true,
+                    fetch: jest.fn(),
+                    messages: { fetch: jest.fn().mockResolvedValue(new Map()) },
+                    send
+                })
+            },
+            logger: { debug: jest.fn(), error: jest.fn() }
+        } as any
+        await Accomplice.prototype.createOrUpdateLeaderboardEmbed.call(bot, 'lb1')
+        expect(send).toHaveBeenCalled()
+        expect(Leaderboard.update).toHaveBeenCalledWith(
+            { messageSnowflake: 'new' },
+            { where: { uuid: 'lb1' } }
+        )
+    })
+
+    it('logs when channel invalid', async () => {
+        const leaderboard = {
+            uuid: 'lb1',
+            channelSnowflake: 'chan',
+            messageSnowflake: null,
+            defaultLeaderboardTrackerId: null
+        }
+        const Leaderboard = {
+            findOne: jest.fn().mockResolvedValue(leaderboard)
+        }
+        const bot = {
+            sequelize: { models: { Leaderboard } },
+            channels: { resolve: jest.fn().mockReturnValue(undefined) },
+            logger: { debug: jest.fn(), error: jest.fn() }
+        } as any
+        await Accomplice.prototype.createOrUpdateLeaderboardEmbed.call(bot, 'lb1')
+        expect(bot.logger.error).toHaveBeenCalled()
+    })
+})

--- a/tests/accomplice/registerCommands.test.ts
+++ b/tests/accomplice/registerCommands.test.ts
@@ -1,0 +1,55 @@
+import Accomplice from '../../src/accomplice'
+import * as fs from 'fs/promises'
+
+jest.mock('fs/promises', () => ({ readdir: jest.fn() }))
+
+class DummyCommand {
+    public meta = {
+        name: 'dummy',
+        description: 'd',
+        toJSON: jest.fn().mockReturnValue({ name: 'dummy' })
+    }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public async execute() {}
+}
+
+jest.mock('../../src/commands/Dummy.js', () => ({ __esModule: true, default: DummyCommand }), { virtual: true })
+
+describe('registerCommands', () => {
+    it('loads commands and registers with Discord', async () => {
+        (fs.readdir as jest.Mock).mockResolvedValue(['Dummy.js'])
+        const put = jest.fn().mockResolvedValue(undefined)
+        const findOne = jest.fn().mockResolvedValue({ uuid: '1', commandsState: [] })
+        const update = jest.fn()
+        const bot = {
+            user: { id: 'bot', fetch: jest.fn().mockResolvedValue({ id: 'bot' }) },
+            rest: { put },
+            guilds: { fetch: jest.fn().mockResolvedValue(new Map([['g1', { name: 'Guild' }]])) },
+            sequelize: { models: { Guild: { findOne, update } } },
+            commands: new Map(),
+            timers: new Map(),
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            findPublicChannel: jest.fn()
+        } as any
+        const success = await Accomplice.prototype.registerCommands.call(bot, 'g1')
+        expect(put).toHaveBeenCalled()
+        expect(success).toBe(true)
+        expect(bot.commands.get('dummy')).toBeInstanceOf(DummyCommand)
+    })
+
+    it('throws when guild missing', async () => {
+        (fs.readdir as jest.Mock).mockResolvedValue(['Dummy.js'])
+        const bot = {
+            user: { id: 'bot', fetch: jest.fn().mockResolvedValue({ id: 'bot' }) },
+            rest: { put: jest.fn() },
+            guilds: { fetch: jest.fn().mockResolvedValue(new Map()) },
+            sequelize: { models: { Guild: { findOne: jest.fn(), update: jest.fn() } } },
+            commands: new Map(),
+            timers: new Map(),
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            findPublicChannel: jest.fn()
+        } as any
+        await Accomplice.prototype.registerCommands.call(bot, 'missing')
+        expect(bot.logger.error).toHaveBeenCalled()
+    })
+})

--- a/tests/accomplice/start.test.ts
+++ b/tests/accomplice/start.test.ts
@@ -1,0 +1,35 @@
+beforeEach(() => {
+    process.env.REDIS_ENABLED = 'true'
+    jest.resetModules()
+})
+
+describe('start', () => {
+    it('performs redis check and login', async () => {
+        const { default: Accomplice } = await import('../../src/accomplice')
+        const redis = {
+            connect: jest.fn(),
+            set: jest.fn(),
+            get: jest.fn().mockResolvedValue('success'),
+            del: jest.fn()
+        }
+        const bot = {
+            redis,
+            registerEvents: jest.fn(),
+            login: jest.fn(),
+            prepareSynchronizeGuilds: jest.fn(),
+            registerCommandHandler: jest.fn(),
+            registerCommands: jest.fn(),
+            logger: { error: jest.fn(), debug: jest.fn(), info: jest.fn() }
+        } as any
+        await Accomplice.prototype.start.call(bot)
+        expect(redis.connect).toHaveBeenCalled()
+        expect(redis.set).toHaveBeenCalled()
+        expect(redis.get).toHaveBeenCalled()
+        expect(redis.del).toHaveBeenCalled()
+        expect(bot.registerEvents).toHaveBeenCalled()
+        expect(bot.login).toHaveBeenCalled()
+        expect(bot.prepareSynchronizeGuilds).toHaveBeenCalled()
+        expect(bot.registerCommandHandler).toHaveBeenCalled()
+        expect(bot.registerCommands).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary
- test command registration and guild error path
- test leaderboard embed updates for edit vs creation and invalid channel
- test startup calls redis, event registration, login

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684228472ed08332ac06dff7edff596d