### PR TITLE
Extend reaction event tests

### DIFF
--- a/tests/events/ReactionAdded.test.ts
+++ b/tests/events/ReactionAdded.test.ts
@@ -38,4 +38,102 @@ describe('ReactionAdded event', () => {
         expect(Reaction.create).toHaveBeenCalled()
         expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('lb')
     })
+
+    it('returns early when fetching a partial reaction fails', async () => {
+        const messageReaction = {
+            partial: true,
+            fetch: jest.fn().mockRejectedValue(new Error('fail')),
+            emoji: { name: '😀', id: null, animated: false },
+            message: {}
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn()
+        }
+        const User = {
+            findOrCreate: jest.fn()
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(messageReaction.fetch).toHaveBeenCalled()
+        expect(bot.logger.error).toHaveBeenCalled()
+        expect(Reaction.create).not.toHaveBeenCalled()
+    })
+
+    it('logs and returns when message author is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: null,
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn()
+        }
+        const User = {
+            findOrCreate: jest.fn()
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not identify message author'
+        )
+        expect(Reaction.create).not.toHaveBeenCalled()
+    })
+
+    it('returns when guild lookup fails', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: null
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false])
+        }
+        const User = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false])
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not locate guild'
+        )
+        expect(Reaction.create).not.toHaveBeenCalled()
+    })
 })

--- a/tests/events/ReactionRemoved.test.ts
+++ b/tests/events/ReactionRemoved.test.ts
@@ -41,4 +41,111 @@ describe('ReactionRemoved event', () => {
         expect(Reaction.destroy).toHaveBeenCalledWith({ where: { uuid: 'r1' } })
         expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('lb')
     })
+
+    it('returns early when fetching a partial reaction fails', async () => {
+        const messageReaction = {
+            partial: true,
+            fetch: jest.fn().mockRejectedValue(new Error('fail')),
+            emoji: { name: '😀', id: null, animated: false },
+            message: {}
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn()
+        }
+        const User = {
+            findOrCreate: jest.fn()
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = {
+            findOne: jest.fn(),
+            destroy: jest.fn()
+        }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(messageReaction.fetch).toHaveBeenCalled()
+        expect(bot.logger.error).toHaveBeenCalled()
+        expect(Reaction.destroy).not.toHaveBeenCalled()
+    })
+
+    it('logs and returns when message author is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: null,
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn()
+        }
+        const User = {
+            findOrCreate: jest.fn()
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = {
+            findOne: jest.fn(),
+            destroy: jest.fn()
+        }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not identify message author'
+        )
+        expect(Reaction.destroy).not.toHaveBeenCalled()
+    })
+
+    it('returns when reaction lookup fails', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false])
+        }
+        const User = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false])
+        }
+        const GuildUser = { create: jest.fn() }
+        const Reaction = {
+            findOne: jest.fn().mockResolvedValue(null),
+            destroy: jest.fn()
+        }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            "Couldn't locate a reaction to delete"
+        )
+        expect(Reaction.destroy).not.toHaveBeenCalled()
+    })
 })


### PR DESCRIPTION
## Summary
- increase coverage for ReactionAdded and ReactionRemoved events
- simulate partial message fetch failures
- verify logging and early returns for missing message authors
- cover cases where guild or reaction lookup fails

## Testing
- `yarn install --mode=skip-build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6842316b58ac83328a30aee4434a7516