### PR TITLE
Add reaction event edge case tests

### DIFF
--- a/tests/commands/Debug.test.ts
+++ b/tests/commands/Debug.test.ts
@@ -13,4 +13,46 @@ describe('Debug command', () => {
     const embed = reply.mock.calls[0][0].embeds[0]
     expect(embed.data.title).toBe('Permission Denied')
   })
+
+  it('showTimers reports empty list', async () => {
+    const reply = jest.fn()
+    const interaction = { reply } as any
+    const bot = { timers: new Map() } as any
+    const cmd = new DebugCommand()
+    await cmd.showTimers(bot, interaction)
+    const embed = reply.mock.calls[0][0].embeds[0]
+    expect(embed.data.description).toBe('No timers in memory.')
+  })
+
+  it('showTimers lists timers when present', async () => {
+    const reply = jest.fn()
+    const interaction = { reply } as any
+    const bot = { timers: new Map([['t1', 1], ['t2', 2]]) } as any
+    const cmd = new DebugCommand()
+    await cmd.showTimers(bot, interaction)
+    const embed = reply.mock.calls[0][0].embeds[0]
+    expect(embed.data.description).toContain('t1')
+    expect(embed.data.description).toContain('t2')
+  })
+
+  it('clearTimer handles unknown timer', async () => {
+    const reply = jest.fn()
+    const interaction = { options: { getString: () => 't1' }, reply } as any
+    const bot = { timers: new Map() } as any
+    const cmd = new DebugCommand()
+    await cmd.clearTimer(bot, interaction)
+    const embed = reply.mock.calls[0][0].embeds[0]
+    expect(embed.data.description).toBe('No timer found with name t1.')
+  })
+
+  it('showEmbed reports missing file', async () => {
+    const reply = jest.fn()
+    const interaction = {
+      options: { getString: (name: string) => (name === 'embed-name' ? 'nope' : null) },
+      reply
+    } as any
+    const cmd = new DebugCommand()
+    await cmd.showEmbed({} as any, interaction)
+    expect(reply).toHaveBeenCalledWith('No embed found with name nope.')
+  })
 })

--- a/tests/events/ReactionAdded.test.ts
+++ b/tests/events/ReactionAdded.test.ts
@@ -1,8 +1,6 @@
 import ReactionAdded from '../../src/events/ReactionAdded'
-import { ReactionType } from '../../src/sequelize/types/reaction'
-
 jest.mock('../../src/util/emoji', () => ({
-    getEmojiType: () => ReactionType.Emoji,
+    getEmojiType: jest.fn().mockReturnValue('emoji'),
     normalizeEmoji: (e: string) => `norm:${e}`
 }))
 
@@ -37,5 +35,116 @@ describe('ReactionAdded event', () => {
         await event.execute({ args: [messageReaction, reactor], bot })
         expect(Reaction.create).toHaveBeenCalled()
         expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('lb')
+    })
+
+    it('handles partial message fetch failure', async () => {
+        const messageReaction = {
+            partial: true,
+            fetch: jest.fn().mockRejectedValue('fail'),
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild: {}, User: {}, GuildUser: {}, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(messageReaction.fetch).toHaveBeenCalled()
+        expect(bot.logger.error).toHaveBeenCalled()
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when message author is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: { author: null, id: 'm1', guildId: 'g1' }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild: {}, User: {}, GuildUser: {}, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not identify message author'
+        )
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when guild id is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: null
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = { findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false]) }
+        const User = { findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false]) }
+        const GuildUser = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not locate guild'
+        )
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when emoji type cannot be determined', async () => {
+        const emojiUtil = require('../../src/util/emoji') as any
+        emojiUtil.getEmojiType.mockReturnValueOnce(undefined)
+
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false])
+        }
+        const User = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false])
+        }
+        const GuildUser = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionAdded()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith('Failed to determine emoji type')
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
     })
 })

--- a/tests/events/ReactionRemoved.test.ts
+++ b/tests/events/ReactionRemoved.test.ts
@@ -1,8 +1,6 @@
 import ReactionRemoved from '../../src/events/ReactionRemoved'
-import { ReactionType } from '../../src/sequelize/types/reaction'
-
 jest.mock('../../src/util/emoji', () => ({
-    getEmojiType: () => ReactionType.Emoji,
+    getEmojiType: jest.fn().mockReturnValue('emoji'),
     normalizeEmoji: (e: string) => `norm:${e}`
 }))
 
@@ -40,5 +38,120 @@ describe('ReactionRemoved event', () => {
         await event.execute({ args: [messageReaction, reactor], bot })
         expect(Reaction.destroy).toHaveBeenCalledWith({ where: { uuid: 'r1' } })
         expect(bot.createOrUpdateLeaderboardEmbed).toHaveBeenCalledWith('lb')
+    })
+
+    it('handles partial message fetch failure', async () => {
+        const messageReaction = {
+            partial: true,
+            fetch: jest.fn().mockRejectedValue('fail'),
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild: {}, User: {}, GuildUser: {}, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(messageReaction.fetch).toHaveBeenCalled()
+        expect(bot.logger.error).toHaveBeenCalled()
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when message author is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: { author: null, id: 'm1', guildId: 'g1' }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild: {}, User: {}, GuildUser: {}, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not identify message author'
+        )
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when guild id is missing', async () => {
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: null
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = { findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false]) }
+        const User = { findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false]) }
+        const GuildUser = { create: jest.fn() }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction: {} } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith(
+            'Failed to log reaction, could not locate guild'
+        )
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
+    })
+
+    it('logs when emoji type cannot be determined', async () => {
+        const emojiUtil = require('../../src/util/emoji') as any
+        emojiUtil.getEmojiType.mockReturnValueOnce(undefined)
+
+        const messageReaction = {
+            partial: false,
+            emoji: { name: '😀', id: null, animated: false },
+            message: {
+                author: { id: 'u1', bot: false },
+                id: 'm1',
+                guildId: 'g1'
+            }
+        } as any
+        const reactor = { id: 'u2', bot: false } as any
+        const Guild = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'gid' }, false])
+        }
+        const User = {
+            findOrCreate: jest.fn().mockResolvedValue([{ uuid: 'uid' }, false])
+        }
+        const GuildUser = { create: jest.fn() }
+        const ReactionModel = {
+            findOne: jest.fn().mockResolvedValue({ uuid: 'r1' }),
+            destroy: jest.fn()
+        }
+        const bot = {
+            user: { id: 'bot' },
+            sequelize: { models: { Guild, User, GuildUser, Reaction: ReactionModel } },
+            logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+            locateLeaderboardsForReaction: jest.fn(),
+            createOrUpdateLeaderboardEmbed: jest.fn()
+        } as any
+        const event = new ReactionRemoved()
+        await event.execute({ args: [messageReaction, reactor], bot })
+        expect(bot.logger.error).toHaveBeenCalledWith('Failed to determine emoji type')
+        expect(bot.createOrUpdateLeaderboardEmbed).not.toHaveBeenCalled()
     })
 })

--- a/tests/modules/logger.test.ts
+++ b/tests/modules/logger.test.ts
@@ -1,6 +1,9 @@
+jest.mock('fs/promises', () => ({ mkdir: jest.fn().mockResolvedValue(undefined) }))
+
 describe('logger module', () => {
     beforeEach(() => {
         delete process.env.LOG_LEVEL
+        delete process.env.LOG_TO_FILE
         jest.resetModules()
     })
 
@@ -9,5 +12,13 @@ describe('logger module', () => {
         jest.resetModules()
         const logger = require('../../src/modules/logger').default
         expect(logger.level).toBe('error')
+    })
+
+    it('calls mkdir when LOG_TO_FILE set', async () => {
+        process.env.LOG_TO_FILE = 'true'
+        jest.resetModules()
+        const { mkdir } = require('fs/promises')
+        require('../../src/modules/logger')
+        expect(mkdir).toHaveBeenCalledWith('./data')
     })
 })


### PR DESCRIPTION
## Summary
- expand ReactionAdded tests with failure branches
- expand ReactionRemoved tests with failure branches

## Testing
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68420fb4c978833288ce1f5dc91f4d20